### PR TITLE
Fixed instances of "Native Script" to be "NativeScript"

### DIFF
--- a/lib/frameworks/nativescript.tsx
+++ b/lib/frameworks/nativescript.tsx
@@ -2,7 +2,7 @@ import { Framework } from "./";
 
 export const nativescript: Framework = {
   slug: "nativescript",
-  name: "Native Script",
+  name: "NativeScript",
   maintainer: "OpenJS Foundation",
   short_description: "Build truly native apps with JavaScript.",
   long_description: (
@@ -27,24 +27,24 @@ export const nativescript: Framework = {
     {
       title: "Cross-platform",
       description:
-        "Native Script allows developers to build mobile apps for multiple platforms, including Android and iOS, using a single codebase.",
+        "NativeScript allows developers to build mobile apps for multiple platforms, including Android and iOS, using a single codebase.",
     },
     {
       title: "Native APIs",
       description:
-        "Native Script provides a bridge to all native APIs via JavaScript, without having to write anything in Swift or Kotlin. This means that developers can access native functionality such as camera, contacts, and file storage.",
+        "NativeScript provides a bridge to all native APIs via JavaScript, without having to write anything in Swift or Kotlin. This means that developers can access native functionality such as camera, contacts, and file storage.",
     },
   ],
   cons: [
     {
       title: "Performance",
       description:
-        "Native Script uses JavaScript as a bridge to Native APIs, which is limited to a single-thread and may not perform as well as those built natively.",
+        "NativeScript uses JavaScript as a bridge to Native APIs, which is limited to a single-thread and may not perform as well as those built natively.",
     },
     {
       title: "Emerging Community",
       description:
-        "Despite being around for a while, the Native Script is not as popular as other frameworks, which means that there is not a lot of tutorials, and examples available to help developers apps.",
+        "Despite being around for a while, the NativeScript is not as popular as other frameworks, which means that there is not a lot of tutorials, and examples available to help developers apps.",
     },
   ],
   releases: {
@@ -66,7 +66,7 @@ export const nativescript: Framework = {
     followers: 70_700,
   },
   discord: {
-    name: "Native Script",
+    name: "NativeScript",
     href: "https://discord.com/invite/RgmpGky9GR",
     members: 4_246,
   },


### PR DESCRIPTION
The framework's name is one word: NativeScript. Performed a rename of "Native Script" to "NativeScript"